### PR TITLE
FIX: time formatting on `OrdersList`

### DIFF
--- a/application/src/components/view-orders/ordersList.js
+++ b/application/src/components/view-orders/ordersList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { dateService } from '../../services/date.service';
 
 const OrdersList = (props) => {
     const { orders } = props;
@@ -7,6 +8,10 @@ const OrdersList = (props) => {
             <h2>There are no orders to display</h2>
         </div>
     );
+
+    function formatDateTime(dateTime) {
+        return dateService.convertDateTimeToTwelveHour(dateTime);
+    }
 
     return orders.map(order => {
         const createdDate = new Date(order.createdAt);
@@ -17,7 +22,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {`${formatDateTime(createdDate)}`}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">

--- a/application/src/services/date.service.js
+++ b/application/src/services/date.service.js
@@ -1,0 +1,7 @@
+export const dateService = {
+  convertDateTimeToTwelveHour,
+};
+
+function convertDateTimeToTwelveHour(dateTime) {
+	return dateTime.toLocaleTimeString('en-US', { hour12: true });
+}


### PR DESCRIPTION
## Changes
- Create `dateService`
- Use `dateService` to format order times in the "View Orders" tab

## Purpose
The date was not formatting correctly ([Issue](https://github.com/Shift3/react-challenge-project-jan-2023/issues/2))

## Approach
Use the `dateService` to format the date correctly

## Pre-Testing TODOs
- login

## Testing Steps
- place an order in the "Order Form" tab
- open the "view orders tab"
- observe that the order times now display correctly

## Learning
The mitochondria is the powerhouse of the cell.

Closes https://github.com/Shift3/react-challenge-project-jan-2023/issues/2
