### PR TITLE
TEST: Add unit test for correct time display

### DIFF
--- a/application/src/components/view-orders/ordersList.test.js
+++ b/application/src/components/view-orders/ordersList.test.js
@@ -55,4 +55,20 @@ describe('Orders List', () => {
         expect(screen.getByText(/^.*888.*$/gm)).toBeInTheDocument();
 
     });
+
+    test('renders orders with correctly formatted times', () => {
+        const hoursMinutesSecondsRegex = /((?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d)/g;
+        const createdAt = 'Sat Apr 01 2023 11:44:07 GMT-0700 (Pacific Daylight Time)';
+
+        const orders = [{
+            _id: 1,
+            order_item: "Food",
+            quantity: "777",
+            createdAt,
+        }];
+
+        render(<OrdersList orders={orders} />)
+
+        expect(screen.getByText(hoursMinutesSecondsRegex)).toBeInTheDocument();
+    });
 })


### PR DESCRIPTION
## Changes
- Add Unit Test to ensure formatted time renders on `OrdersList`

## Purpose
To ensure formatted time renders on `OrdersList`

## Approach
Add Unit Test to ensure formatted time renders on `OrdersList`

## Pre-Testing TODOs
- login
- ensure that you have previously placed orders in the app
- ensure that you have run `npm i`

## Testing Steps
- run `npm run test`
- see that all tests pass

## Learning
- copy/pasta the regex I found here: https://stackoverflow.com/questions/24347895/regex-for-hour-minute-and-second-format-hhmmss
- the mitochondria is the powerhouse of the cell

Closes https://github.com/Shift3/react-challenge-project-jan-2023/issues/3
