### PR TITLE
FIX: Retrieve user from Redux and include in Order Form 

### DIFF
--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:


### PR DESCRIPTION
## Changes
- reference correct field (`email` instead of `login`) on the `action.payload` object

## Purpose
- To fix the bug that prevented the retrieval of the user from Redux and include in Order Form

## Approach
- reference correct field (`email` instead of `login`) on the `action.payload` object

## Pre-Testing TODOs
- login
- place an order in the "Order Form" tab
- open the "view orders tab"

## Testing Steps
- The "Ordered By" field should now be populated with the current user's email.

## Learning
- the mitochondria is the powerhouse of the cell.

Closes https://github.com/Shift3/react-challenge-project-jan-2023/issues/4
