### PR TITLE
FEAT: API call refactor

### DIFF
--- a/application/src/components/order/order.js
+++ b/application/src/components/order/order.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { Template } from '../../components';
 import { OrderForm } from '../../components';
-import { requestHandler } from '../../services/request-handler.service';
+import { ordersService } from '../../services/orders.service';
 import './order.css';
 
 import usePlaceOrder from '../../hooks/usePlaceOrder';
@@ -20,10 +20,12 @@ export default function Order(props) {
     const submitOrder = () => {
         if (orderItem === "") return;
 
-        requestHandler.makeRequest('POST', 'add-order', {
-            order_item: orderItem,
+        const orderedBy = auth && auth.email
+
+        ordersService.createOrder({
+            orderItem,
             quantity,
-            ordered_by: auth.email || 'Unknown!',
+            orderedBy,
         })
         .then(response => console.log('Success', JSON.stringify(response)))
         .catch(error => console.error(error));

--- a/application/src/components/order/order.js
+++ b/application/src/components/order/order.js
@@ -2,11 +2,10 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { Template } from '../../components';
 import { OrderForm } from '../../components';
+import { requestHandler } from '../../services/request-handler.service';
 import './order.css';
 
 import usePlaceOrder from '../../hooks/usePlaceOrder';
-import { SERVER_IP } from '../../private';
-const ADD_ORDER_URL = `${SERVER_IP}/api/add-order`;
 
 export default function Order(props) {
     const {
@@ -19,21 +18,15 @@ export default function Order(props) {
     const auth = useSelector((state) => state.auth);
 
     const submitOrder = () => {
-      if (orderItem === "") return;
-      fetch(ADD_ORDER_URL, {
-          method: 'POST',
-          body: JSON.stringify({
-              order_item: orderItem,
-              quantity,
-              ordered_by: auth.email || 'Unknown!',
-          }),
-          headers: {
-              'Content-Type': 'application/json'
-          }
-      })
-      .then(res => res.json())
-      .then(response => console.log('Success', JSON.stringify(response)))
-      .catch(error => console.error(error));
+        if (orderItem === "") return;
+
+        requestHandler.makeRequest('POST', 'add-order', {
+            order_item: orderItem,
+            quantity,
+            ordered_by: auth.email || 'Unknown!',
+        })
+        .then(response => console.log('Success', JSON.stringify(response)))
+        .catch(error => console.error(error));
   }
 
     return (

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector, connect } from 'react-redux';
-import { requestHandler } from '../../services/request-handler.service';
+import { ordersService } from '../../services/orders.service';
 import { getOrders } from '../../redux/actions/orderActions'
 
 import { OrderForm, Template } from '../../components';
@@ -68,11 +68,11 @@ function ViewOrders(props) {
     }
 
     const submitEditOrder = () => {
-        requestHandler.makeRequest('POST', 'edit-order', {
+        ordersService.editOrder({
             id: editingOrder._id,
-            order_item: orderItem,
+            orderItem,
             quantity,
-            ordered_by: auth.email || 'Unknown!',
+            orderedBy: auth && auth.email,
         })
         .then(() => {
             props.triggerGetOrders();
@@ -82,7 +82,7 @@ function ViewOrders(props) {
     }
 
     const deleteOrder = order => {
-        requestHandler.makeRequest('POST', 'delete-order', { id: order._id })
+        ordersService.deleteOrder(order._id)
             .then(() => {
                 props.triggerGetOrders();
             })

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -68,8 +68,7 @@ function ViewOrders(props) {
     }
 
     const submitEditOrder = () => {
-        ordersService.editOrder({
-            id: editingOrder._id,
+        ordersService.editOrder(editingOrder._id, {
             orderItem,
             quantity,
             orderedBy: auth && auth.email,

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -83,7 +83,9 @@ function ViewOrders(props) {
 
     const deleteOrder = order => {
         requestHandler.makeRequest('POST', 'delete-order', { id: order._id })
-            .then(response => console.log("Success", JSON.stringify(response)))
+            .then(() => {
+                props.triggerGetOrders();
+            })
             .catch(error => console.error(error));
     }
 

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, connect } from 'react-redux';
 import { requestHandler } from '../../services/request-handler.service';
+import { getOrders } from '../../redux/actions/orderActions'
 
 import { OrderForm, Template } from '../../components';
 import OrdersList from './ordersList';
@@ -9,10 +10,16 @@ import Modal from '../modal/modal';
 
 import usePlaceOrder from '../../hooks/usePlaceOrder';
 
-export default function ViewOrders(props) {
-    const [orders, setOrders] = useState([]);
+const mapActionsToProps = dispatch => ({
+    triggerGetOrders() {
+        dispatch(getOrders());
+    }
+});
+
+function ViewOrders(props) {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const auth = useSelector((state) => state.auth);
+    const orders = useSelector(({ orders }) => orders.orderList);
 
     const {
         menuItemChosen,
@@ -29,16 +36,7 @@ export default function ViewOrders(props) {
     } = usePlaceOrder();
 
     useEffect(() => {
-        requestHandler.makeRequest('GET', 'current-orders')
-            .then(({ success, orders }) => {
-                if (!success) {
-                    console.log('Error getting orders');
-
-                    return;
-                }
-
-                setOrders(orders);
-            });
+        props.triggerGetOrders();
     }, [])
 
     useEffect(() => {
@@ -108,3 +106,5 @@ export default function ViewOrders(props) {
         </Template>
     );
 }
+
+export default connect(null, mapActionsToProps)(ViewOrders);

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -74,7 +74,10 @@ function ViewOrders(props) {
             quantity,
             ordered_by: auth.email || 'Unknown!',
         })
-        .then(response => console.log("Success", JSON.stringify(response)))
+        .then(() => {
+            props.triggerGetOrders();
+            toggleModal();
+        })
         .catch(error => console.error(error));
     }
 

--- a/application/src/redux/actions/authActions.js
+++ b/application/src/redux/actions/authActions.js
@@ -1,5 +1,5 @@
 import { LOGIN, LOGOUT } from './types';
-import { SERVER_IP } from '../../private'
+import { requestHandler } from '../../services/request-handler.service';
 
 const finishLogin = (email, token) => {
     return {
@@ -13,21 +13,15 @@ const finishLogin = (email, token) => {
 
 export const loginUser = (email, password) => {
     return (dispatch) => {
-        fetch(`${SERVER_IP}/api/login`, {
-            method: 'POST',
-            body: JSON.stringify({
-                email,
-                password
-            }),
-            headers: {
-                'Content-Type': 'application/json'
-            },
-        }).then(response => response.json())
-        .then(response => {
-            if (response.success) {
-                dispatch(finishLogin(response.email, response.token));
-            }
+        requestHandler.makeRequest('POST', 'login', {
+            email,
+            password
         })
+        .then(({ success, email, token }) => {
+            if (!success) return console.log('login failed');
+
+            dispatch(finishLogin(email, token));
+        });
     };
 }
 

--- a/application/src/redux/actions/orderActions.js
+++ b/application/src/redux/actions/orderActions.js
@@ -1,0 +1,24 @@
+import { GET_ORDERS } from './types';
+import { requestHandler } from '../../services/request-handler.service';
+
+export const setOrders = orderList => {
+  return {
+    type: GET_ORDERS,
+    payload: { orderList },
+  }
+}
+
+export const getOrders = () => {
+  return dispatch => {
+    return requestHandler.makeRequest('GET', 'current-orders')
+      .then(({ success, orders }) => {
+        if (!success) {
+            console.log('Error getting orders');
+
+            return;
+        }
+
+        dispatch(setOrders(orders));
+      });
+  }
+}

--- a/application/src/redux/actions/orderActions.js
+++ b/application/src/redux/actions/orderActions.js
@@ -13,9 +13,9 @@ export const getOrders = () => {
     return requestHandler.makeRequest('GET', 'current-orders')
       .then(({ success, orders }) => {
         if (!success) {
-            console.log('Error getting orders');
+          console.log('Error getting orders');
 
-            return;
+          return Promise.reject('Error getting orders');
         }
 
         dispatch(setOrders(orders));

--- a/application/src/redux/actions/orderActions.js
+++ b/application/src/redux/actions/orderActions.js
@@ -1,5 +1,5 @@
 import { GET_ORDERS } from './types';
-import { requestHandler } from '../../services/request-handler.service';
+import { ordersService } from '../../services/orders.service';
 
 export const setOrders = orderList => {
   return {
@@ -10,14 +10,8 @@ export const setOrders = orderList => {
 
 export const getOrders = () => {
   return dispatch => {
-    return requestHandler.makeRequest('GET', 'current-orders')
-      .then(({ success, orders }) => {
-        if (!success) {
-          console.log('Error getting orders');
-
-          return Promise.reject('Error getting orders');
-        }
-
+    return ordersService.getOrdersList()
+      .then((orders) => {
         dispatch(setOrders(orders));
       });
   }

--- a/application/src/redux/actions/types.js
+++ b/application/src/redux/actions/types.js
@@ -1,2 +1,5 @@
 export const LOGIN = 'login';
 export const LOGOUT = 'logout';
+
+// orders
+export const GET_ORDERS = 'get_orders';

--- a/application/src/redux/actions/types.js
+++ b/application/src/redux/actions/types.js
@@ -1,3 +1,4 @@
+// auth
 export const LOGIN = 'login';
 export const LOGOUT = 'logout';
 

--- a/application/src/redux/reducers/index.js
+++ b/application/src/redux/reducers/index.js
@@ -1,8 +1,8 @@
 import { combineReducers } from 'redux';
-import TempReducer from './tempReducer';
 import authReducer from './authReducer';
+import orderReducer from './orderReducer';
 
 export default combineReducers({
-  temp: TempReducer,
+  orders: orderReducer,
   auth: authReducer,
 });

--- a/application/src/redux/reducers/orderReducer.js
+++ b/application/src/redux/reducers/orderReducer.js
@@ -1,0 +1,11 @@
+import { GET_ORDERS } from '../actions/types';
+const INITIAL_STATE = { orderList: [] };
+
+export default (state = INITIAL_STATE, action) => {
+  switch (action.type) {
+    case GET_ORDERS:
+        return { ...state, orderList: action.payload.orderList };
+    default:
+        return state;
+  }
+}

--- a/application/src/redux/reducers/tempReducer.js
+++ b/application/src/redux/reducers/tempReducer.js
@@ -1,9 +1,0 @@
-const INITIAL_STATE = { test: '' };
-
-export default (state = INITIAL_STATE, action) => {
-  switch (action.type) {
-    default:
-      return state;
-  }
-
-}

--- a/application/src/services/orders.service.js
+++ b/application/src/services/orders.service.js
@@ -1,0 +1,76 @@
+import { requestHandler } from './request-handler.service';
+
+export const ordersService = {
+  getOrdersList,
+  createOrder,
+  editOrder,
+  deleteOrder,
+};
+
+function getOrdersList() {
+  return requestHandler.makeRequest('GET', 'current-orders')
+    .then(({ success, orders }) => {
+      if (!success) {
+        console.log('Error getting orders');
+
+        return Promise.reject('Error getting orders');
+      }
+
+      return orders;
+    });
+}
+
+function createOrder(body = {}) {
+  const { orderItem, quantity, orderedBy } = body;
+
+  return requestHandler.makeRequest('POST', 'add-order', {
+    order_item: orderItem,
+    quantity,
+    ordered_by: orderedBy || 'Unknown!',
+  })
+  .then(response => {
+    if (!response || !response.success) {
+      console.log('Error creating order');
+
+      return Promise.reject('Error getting orders');
+    }
+
+    return response;
+  });
+}
+
+function editOrder(body = {}) {
+  const { id, orderItem, quantity, orderedBy } = body;
+
+  console.log( 'edit' );
+  console.log( body );
+
+  return requestHandler.makeRequest('POST', 'edit-order', {
+    id,
+    order_item: orderItem,
+    quantity,
+    ordered_by: orderedBy || 'Unknown!',
+  })
+  .then(response => {
+    if (!response || !response.success) {
+      console.log('Error editing order');
+
+      return Promise.reject('Error getting orders');
+    }
+
+    return response;
+  });
+}
+
+function deleteOrder(id) {
+  return requestHandler.makeRequest('POST', 'delete-order', { id })
+    .then(response => {
+      if (!response || !response.success) {
+        console.log('Error getting orders');
+
+        return Promise.reject('Error deleting order');
+      }
+
+      return response;
+    });
+}

--- a/application/src/services/orders.service.js
+++ b/application/src/services/orders.service.js
@@ -39,14 +39,11 @@ function createOrder(body = {}) {
   });
 }
 
-function editOrder(body = {}) {
-  const { id, orderItem, quantity, orderedBy } = body;
-
-  console.log( 'edit' );
-  console.log( body );
+function editOrder(orderId, body = {}) {
+  const { orderItem, quantity, orderedBy } = body;
 
   return requestHandler.makeRequest('POST', 'edit-order', {
-    id,
+    id: orderId,
     order_item: orderItem,
     quantity,
     ordered_by: orderedBy || 'Unknown!',

--- a/application/src/services/request-handler.service.js
+++ b/application/src/services/request-handler.service.js
@@ -1,0 +1,22 @@
+import { SERVER_IP } from '../private';
+const BASE_URL = `${SERVER_IP}/api`;
+
+export const requestHandler = {
+  makeRequest,
+};
+
+
+function makeRequest(method, endpoint, data = {}) {
+  if (!endpoint) return Promise.reject('Missing endpoint');
+
+  const url = `${BASE_URL}/${endpoint}`;
+
+  const config = {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+  };
+
+  if (method === 'POST') config.body = JSON.stringify(data);
+
+  return fetch(url, config).then(response => response.json());
+}


### PR DESCRIPTION
## Changes
- abstract `fetch` functionality into a `request-handler` service
- create `orders.service` to group `order` api calls
- set up reducer/actions/types for `orders`
- remove `tempReducer` file

## Purpose
- DRY up API calls

## Approach
- by leveraging a service-oriented system, we can remove a lot of the pain points of making api calls directly (typos, bug-hunting, etc.)

## Pre-Testing TODOs
N/A

## Testing Steps
- login
- ensure that CRUD operations are still possible in the app.

## Learning
- https://redux.js.org/usage/writing-logic-thunks
- the mitochondria is the powerhouse of the cell.

Closes https://github.com/Shift3/react-challenge-project-jan-2023/issues/9
